### PR TITLE
ci(release): publish GHCR image on GitHub Release (tag + latest) & al…

### DIFF
--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -1,52 +1,43 @@
 ﻿name: Publish Release image (GHCR)
 
 on:
-  release:
-    types: [published]
+    release:
+        types: [ published ]
+    workflow_dispatch:
+        inputs:
+            tag:
+                description: "Tag rilis yang akan dipublish (mis. v0.2.0)"
+                required: true
 
 permissions:
-  contents: read
-  packages: write
+    contents: read
+    packages: write
 
 jobs:
-  publish:
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v4
-        with:
-          fetch-depth: 0
+    build-and-push:
+        runs-on: ubuntu-latest
+        env:
+            REL_TAG: ${{ github.event.release.tag_name || inputs.tag }}
+            IMAGE: ghcr.io/${{ github.repository_owner }}/todolist
+        steps:
+            -   uses: actions/checkout@v4
+                with:
+                    fetch-depth: 0
 
-      - name: Setup Buildx
-        uses: docker/setup-buildx-action@v3
+            # Set versi Maven = tag rilis, supaya /api/version bukan SNAPSHOT
+            -   name: Set Maven version from tag
+                run: ./mvnw -B -q versions:set -DnewVersion=${REL_TAG} versions:commit
 
-      - name: Login GHCR
-        uses: docker/login-action@v3
-        with:
-          registry: ghcr.io
-          username: ${{ github.actor }}
-          password: ${{ secrets.GITHUB_TOKEN }}
+            -   name: Build jar (skip tests)
+                run: ./mvnw -B -q -DskipTests package
 
-      - name: Resolve TAG and REVISION
-        id: ver
-        shell: bash
-        run: |
-          TAG="${{ github.event.release.tag_name }}"
-          REV="${TAG#v}"          # strip 'v' -> 0.2.0
-          echo "tag=$TAG" >> "$GITHUB_OUTPUT"
-          echo "rev=$REV" >> "$GITHUB_OUTPUT"
+            -   name: Login to GHCR
+                run: echo "${{ secrets.GITHUB_TOKEN }}" | docker login ghcr.io -u ${{ github.actor }} --password-stdin
 
-      - name: Build & Push (tag + latest)
-        uses: docker/build-push-action@v6
-        with:
-          context: .
-          push: true
-          tags: |
-            ghcr.io/${{ github.repository }}:${{ steps.ver.outputs.tag }}
-            ghcr.io/${{ github.repository }}:latest
-          build-args: |
-            REVISION=${{ steps.ver.outputs.rev }}
-            GIT_SHA=${{ github.sha }}
-            GIT_REF=${{ steps.ver.outputs.tag }}
-          cache-from: type=gha
-          cache-to: type=gha,mode=max
+            -   name: Build & push images (tag rilis + latest)
+                run: |
+                    docker build \
+                      -t "${IMAGE}:${REL_TAG}" \
+                      -t "${IMAGE}:latest" .
+                    docker push "${IMAGE}:${REL_TAG}"
+                    docker push "${IMAGE}:latest"


### PR DESCRIPTION
…low manual run

- Set Maven version = release tag so /api/version reflects real version (no SNAPSHOT)
- Build with mvnw and push ghcr.io/<owner>/todolist:<tag> and :latest
- Added workflow_dispatch 'tag' input to backfill existing releases